### PR TITLE
SageMaker 2 upgrade

### DIFF
--- a/healthcare-fraud-identification-using-PCA-anomaly-detection.ipynb
+++ b/healthcare-fraud-identification-using-PCA-anomaly-detection.ipynb
@@ -569,10 +569,10 @@
    "outputs": [],
    "source": [
     "# traing wordtovec model on diagnosis description tokens\n",
-    "model_drg = Word2Vec(tmp_diagnosis_tokenized, min_count = 1, size = 72, window = 5, iter = 30)\n",
+    "model_drg = Word2Vec(tmp_diagnosis_tokenized, min_count = 1, vector_size = 72, window = 5, epochs = 30)\n",
     "print(model_drg)\n",
-    "diagnosis_words = list(model_drg.wv.vocab)\n",
-    "print(columnize.columnize(diagnosis_words, displaywidth=80, ljust=False))"
+    "diagnosis_words = list(model_drg.wv.key_to_index.keys())\n",
+    "print(columnize.columnize(diagnosis_words, displaywidth=80, ljust=False))\n"
    ]
   },
   {
@@ -597,8 +597,8 @@
     "    labels = []\n",
     "    tokens = []\n",
     "\n",
-    "    for word in model.wv.vocab:\n",
-    "        tokens.append(model[word])\n",
+    "    for word in model.wv.key_to_index:\n",
+    "        tokens.append(model.wv[word])\n",
     "        labels.append(word)\n",
     "    \n",
     "    tsne_model = TSNE(perplexity=10, n_components=2, init='pca', n_iter=2500, random_state=10)\n",
@@ -640,7 +640,7 @@
    "outputs": [],
    "source": [
     "# test most similiar for some word from model_drg.wv.keywords\n",
-    "model_drg.most_similar('diagnosis')"
+    "model_drg.wv.most_similar('diagnosis')"
    ]
   },
   {
@@ -683,7 +683,7 @@
     "#iterate through list of strings in each diagnosis phrase\n",
     "for i, v in pd.Series(tmp_diagnosis_tokenized).items():\n",
     "    #calculate mean of all word embeddings in each diagnosis phrase\n",
-    "    values.append(model_drg[v].mean(axis =0))\n",
+    "    values.append(model_drg.wv[v].mean(axis =0))\n",
     "    index.append(i)\n",
     "tmp_diagnosis_phrase_vector = pd.DataFrame({'Base DRG code':index, 'DRG_VECTOR':values})\n",
     "display(tmp_diagnosis_phrase_vector.head())"
@@ -804,9 +804,9 @@
    "outputs": [],
    "source": [
     "# traing wordtovec model on procedure description tokens\n",
-    "model_prc = Word2Vec(tmp_procedure_tokenized, min_count = 1, size = 72, window = 5, iter = 100)\n",
+    "model_prc = Word2Vec(tmp_procedure_tokenized, min_count = 1, vector_size = 72, window = 5, epochs = 100)\n",
     "print(model_prc)\n",
-    "procedure_words = list(model_prc.wv.vocab)\n",
+    "procedure_words = list(model_prc.wv.key_to_index)\n",
     "print(columnize.columnize(procedure_words, displaywidth=80, ljust=False))"
    ]
   },
@@ -828,7 +828,7 @@
    "outputs": [],
    "source": [
     "# test most similiar for some word from model_prc.wv.keywords\n",
-    "model_prc.most_similar('nonoperative')"
+    "model_prc.wv.most_similar('nonoperative')"
    ]
   },
   {
@@ -870,7 +870,7 @@
     "#iterate through list of strings in each procedure phrase\n",
     "for i, v in pd.Series(tmp_procedure_tokenized).items():\n",
     "    #calculate mean of all word embeddings in each procedure phrase\n",
-    "    values.append(model_prc[v].mean(axis =0))\n",
+    "    values.append(model_prc.wv[v].mean(axis =0))\n",
     "    index.append(i)\n",
     "tmp_procedure_phrase_vector = pd.DataFrame({'ICD9 primary procedure code':index, 'PRC_VECTOR':values})\n",
     "display(tmp_procedure_phrase_vector.head())"
@@ -995,7 +995,7 @@
    "outputs": [],
    "source": [
     "# Convert data to binary stream.\n",
-    "matrx_train = X_stndrd_train.as_matrix().astype('float32')\n",
+    "matrx_train = X_stndrd_train.values.astype('float32')\n",
     "import io\n",
     "import sagemaker.amazon.common as smac\n",
     "buf_train = io.BytesIO()\n",
@@ -1035,11 +1035,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker import image_uris\n",
     "# select the algorithm container based on this notebook's current location\n",
     "\n",
     "region_name = boto3.Session().region_name\n",
-    "container = get_image_uri(region_name, 'pca')\n",
+    "container = image_uris.retrieve('pca', region_name)\n",
     "\n",
     "print('Using SageMaker PCA container: {} ({})'.format(container, region_name))"
    ]
@@ -1075,8 +1075,8 @@
     "\n",
     "pca = sagemaker.estimator.Estimator(container,\n",
     "                                    role, \n",
-    "                                    train_instance_count=num_instances, \n",
-    "                                    train_instance_type=instance_type,\n",
+    "                                    instance_count=num_instances, \n",
+    "                                    instance_type=instance_type,\n",
     "                                    output_path=output_location,\n",
     "                                    sagemaker_session=sess)"
    ]
@@ -1351,7 +1351,7 @@
     "#serialize test data to binary format for realtime inference for extracting principal components of claim features\n",
     "X_stndrd_test = scaler.transform(X_test)\n",
     "X_stndrd_test = pd.DataFrame(X_stndrd_test, index=X_test.index, columns=X_test.columns)\n",
-    "inference_input = X_stndrd_test.as_matrix().astype('float32')\n",
+    "inference_input = X_stndrd_test.values.astype('float32')\n",
     "buf = io.BytesIO()\n",
     "smac.write_numpy_to_dense_tensor(buf, inference_input)\n",
     "buf.seek(0)"
@@ -1384,11 +1384,12 @@
     "pca_predictor = pca.deploy(initial_instance_count=1,\n",
     "                           instance_type='ml.m4.xlarge')\n",
     "\n",
-    "from sagemaker.predictor import csv_serializer, json_deserializer\n",
+    "from sagemaker.serializers import CSVSerializer\n",
+    "from sagemaker.deserializers import JSONDeserializer\n",
     "\n",
-    "pca_predictor.content_type = 'text/csv'\n",
-    "pca_predictor.serializer = csv_serializer\n",
-    "pca_predictor.deserializer = json_deserializer"
+    "pca_predictor.__setattr__(pca_predictor.content_type, \"text/csv\")\n",
+    "pca_predictor.serializer = CSVSerializer()\n",
+    "pca_predictor.deserializer = JSONDeserializer()"
    ]
   },
   {
@@ -1457,7 +1458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* fixed breaking changes for Gensim>= 4.0.0.0
 - 'Word2Vec' object is not subscriptable model.words
-  AttributeError: The vocab attribute was removed from KeyedVector in Gensim 4.0.0.

* fixed breaking changes for sagemaker>=2
- The method get_image_uri has been renamed in sagemaker>=2.
- train_instance_count has been renamed in sagemaker>=2.
- train_instance_type has been renamed in sagemaker>=2.
- AttributeError: can't set attribute (content_type = 'text/csv')
- The csv_serializer has been renamed in sagemaker>=2.
- The json_deserializer has been renamed in sagemaker>=2.

* fixed breaking change for pandas>=0.23.0:
pandas.DataFrame.as_matrix Deprecated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
